### PR TITLE
Fallback to using obsidian to fill in lava

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/HighwayTools.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/HighwayTools.kt
@@ -332,7 +332,7 @@ object HighwayTools : Module() {
             }
             is BlockLiquid -> {
                 var filler = fillerMat
-                if (isInsideBuild(blockTask.blockPos)) filler = material
+                if (isInsideBuild(blockTask.blockPos) || fillerMatLeft == 0) filler = material
                 if (mc.world.getBlockState(blockTask.blockPos).getValue(BlockLiquid.LEVEL) != 0) {
                     updateTask(blockTask, TaskState.LIQUID_FLOW)
                     updateTask(blockTask, filler)
@@ -399,7 +399,7 @@ object HighwayTools : Module() {
             }
             is BlockLiquid -> {
                 var filler = fillerMat
-                if (isInsideBuild(blockTask.blockPos)) filler = material
+                if (isInsideBuild(blockTask.blockPos) || fillerMatLeft == 0) filler = material
                 if (mc.world.getBlockState(blockTask.blockPos).getValue(BlockLiquid.LEVEL) != 0) {
                     updateTask(blockTask, TaskState.LIQUID_FLOW)
                     updateTask(blockTask, filler)
@@ -480,7 +480,7 @@ object HighwayTools : Module() {
             when (val block = mc.world.getBlockState(blockPos).block) {
                 is BlockLiquid -> {
                     var filler = fillerMat
-                    if (isInsideBuild(blockPos)) filler = material
+                    if (isInsideBuild(blockPos) || fillerMatLeft == 0) filler = material
                     when (mc.world.getBlockState(blockPos).getValue(BlockLiquid.LEVEL) != 0) {
                         true -> addTask(blockPos, TaskState.LIQUID_FLOW, filler)
                         false -> addTask(blockPos, TaskState.LIQUID_SOURCE, filler)


### PR DESCRIPTION
If we are out of fillermaterial, fallback to using obsidian. This is
useful for when using inventory manager which automatically throws all
netherrack on the ground.
