### PR TITLE
Allow toggling inventory manager, autoObsidian fix

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/HighwayTools.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/HighwayTools.kt
@@ -4,6 +4,7 @@ import me.zeroeightsix.kami.event.events.RenderWorldEvent
 import me.zeroeightsix.kami.event.events.SafeTickEvent
 import me.zeroeightsix.kami.module.Module
 import me.zeroeightsix.kami.module.modules.player.AutoEat
+import me.zeroeightsix.kami.module.modules.player.InventoryManager
 import me.zeroeightsix.kami.module.modules.player.NoBreakAnimation
 import me.zeroeightsix.kami.process.HighwayToolsProcess
 import me.zeroeightsix.kami.setting.Settings
@@ -11,7 +12,6 @@ import me.zeroeightsix.kami.util.BaritoneUtils
 import me.zeroeightsix.kami.util.BlockUtils
 import me.zeroeightsix.kami.util.InventoryUtils
 import me.zeroeightsix.kami.util.color.ColorHolder
-import me.zeroeightsix.kami.util.combat.SurroundUtils
 import me.zeroeightsix.kami.util.event.listener
 import me.zeroeightsix.kami.util.graphics.ESPRenderer
 import me.zeroeightsix.kami.util.math.CoordinateConverter.asString
@@ -40,7 +40,6 @@ import net.minecraftforge.fml.common.gameevent.TickEvent
 import java.util.*
 import kotlin.collections.ArrayList
 import kotlin.math.abs
-import kotlin.math.round
 import kotlin.math.sqrt
 
 /**
@@ -75,6 +74,7 @@ object HighwayTools : Module() {
     private val interacting = register(Settings.enumBuilder(InteractMode::class.java, "InteractMode").withValue(InteractMode.SPOOF).withVisibility { page.value == Page.BEHAVIOR })
     private val illegalPlacements = register(Settings.booleanBuilder("IllegalPlacements").withValue(true).withVisibility { page.value == Page.BEHAVIOR })
     private val maxReach = register(Settings.floatBuilder("MaxReach").withValue(4.0F).withRange(1.0f, 5.0f).withStep(0.1f).withVisibility { page.value == Page.BEHAVIOR })
+    private val toggleInventoryManager = register(Settings.booleanBuilder("ToggleInventoryManager").withValue(true).withVisibility { page.value == Page.BEHAVIOR })
 
     // config
     private val info = register(Settings.booleanBuilder("ShowInfo").withValue(true).withVisibility { page.value == Page.CONFIG })
@@ -132,6 +132,11 @@ object HighwayTools : Module() {
             return
         }
 
+        /* Turn on inventory manager if the users wants us to control it */
+        if(toggleInventoryManager.value && InventoryManager.isDisabled) {
+            InventoryManager.enable()
+        }
+
         startingBlockPos = mc.player.positionVector.toBlockPos()
         currentBlockPos = startingBlockPos
         playerHotbarSlot = mc.player.inventory.currentItem
@@ -174,6 +179,12 @@ object HighwayTools : Module() {
 
             if (process != null && process.isPresent && process.get() == HighwayToolsProcess) process.get().onLostControl()
         }
+
+        /* Turn off inventory manager if the users wants us to control it */
+        if(toggleInventoryManager.value && InventoryManager.isEnabled) {
+            InventoryManager.disable()
+        }
+
         printDisable()
     }
 


### PR DESCRIPTION
-> Add a toggle to control inventory manager
-> Fix autoObsidian not searching the hotbar in some cases. This was
causing auto-obsidian to incorrectly mine ender chests even though there
were some stacks of obsidian in the hotbar. Also changed the obsidian
and enderchest itemIds to an enum.