### PR TITLE
Possible Fix for AutoObsidian [Not able to Test]

### DIFF
--- a/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoObsidian.kt
+++ b/src/main/java/me/zeroeightsix/kami/module/modules/misc/AutoObsidian.kt
@@ -235,7 +235,7 @@ object AutoObsidian : Module() {
     */
     private fun maxPossibleEnderChests(): Int {
         var maxEnderChests = 0
-        mc.player?.inventory?.mainInventory.let {
+        mc.player?.inventory?.mainInventory?.let {
             val clonedList = ArrayList(it)
             for (itemStack in clonedList) {
                 if(getIdFromItem(itemStack.item) == ItemID.AIR.id) {


### PR DESCRIPTION
**Describe the pull**
AutoObby has an issue where it will continue to pick up Obsidian. Even if your inventory is full so if there is extra obby it will keep you stuck standing over the obby.

**Information**
At line(s) 238: mc.player?.inventory?.mainInventory.let
At line(s) 260: mc.player?.inventory?.mainInventory?.let

Possible fix being instead of mc.player?.inventory?.mainInventory.let insert a another question mark mc.player?.inventory?.mainInventory?.let

Otherwise, remove null values [?] or add a confirmation statement.

If no changes work then I will attempt to start a testing process.

**Additional context**
Could be wrong, but I may be right so this could be helpful. ¯\_(ツ)_/¯
